### PR TITLE
FIX: Blocking of application in case data is available #7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-10-25
+### Fixed
+ - Blocking of application in case data is available [#7]
+
 ## [0.2.0] - 2023-06-09
 ### Fixed
 - Changed type of BMS temperature to int8 [#3]

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
   "name": "SuperSoco485",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Library for reading vehicle information over RS485 interface of Super Soco motorcycles",
   "license": "MIT",
   "frameworks": ["Arduino"],

--- a/src/SuperSoco485.cpp
+++ b/src/SuperSoco485.cpp
@@ -45,18 +45,27 @@ namespace stprograms::SuperSoco485
      */
     void SuperSoco485::update()
     {
+        int availableBytes;
 #ifdef TRACE
         Serial.print("SS485 upd| ");
 #endif
-        if (RS485.available() > 0)
+        availableBytes = RS485.available();
+        if (availableBytes > 0)
         {
 #ifdef TRACE
             Serial.print("data: ");
 #endif
             // read data and parse telegram
+            // FIX #7: read only as much bytes as available. If more bytes should
+            // be read than currently available, the function will still return
+            // only as much bytes as available, but the function will block for
+            // the default timeout of 1 second and wait for more characters.
+            // This will break timing of the application
+            const int bytesToRead = ((unsigned)availableBytes < sizeof(_rawBuffer)) ?
+                                    availableBytes : sizeof(_rawBuffer);
             size_t readBytes = RS485.readBytes(
                 _rawBuffer,
-                sizeof(_rawBuffer));
+                bytesToRead);
 
 #ifdef TRACE
             Serial.print(readBytes);


### PR DESCRIPTION
Now reading only as much bytes from the serial interface as available. Reading more characters than available has the effect that the underlying implementation of the serial stream of the RS485 library will wait for more characters for the default timeout, which  is 1 second. 

A delay as big as this can crash the timing of a using application.

closes #7 